### PR TITLE
Add: support SOCKS proxy for new outgoing connections

### DIFF
--- a/master_server/openttd/send.py
+++ b/master_server/openttd/send.py
@@ -9,23 +9,23 @@ from .protocol.write import (
 
 
 class OpenTTDProtocolSend:
-    def send_PACKET_UDP_MASTER_SESSION_KEY(self, addr, session_key):
+    def send_PACKET_UDP_MASTER_SESSION_KEY(self, addr, session_key, new_connection=False):
         data = write_init(PacketUDPType.PACKET_UDP_MASTER_SESSION_KEY)
         data = write_uint64(data, session_key)
         data = write_presend(data)
-        self.send_packet(addr, data)
+        return self.send_packet(addr, data, new_connection=new_connection)
 
-    def send_PACKET_UDP_MASTER_ACK_REGISTER(self, addr):
+    def send_PACKET_UDP_MASTER_ACK_REGISTER(self, addr, new_connection=False):
         data = write_init(PacketUDPType.PACKET_UDP_MASTER_ACK_REGISTER)
         data = write_presend(data)
-        self.send_packet(addr, data)
+        return self.send_packet(addr, data, new_connection=new_connection)
 
-    def send_PACKET_UDP_CLIENT_FIND_SERVER(self, addr):
+    def send_PACKET_UDP_CLIENT_FIND_SERVER(self, addr, new_connection=False):
         data = write_init(PacketUDPType.PACKET_UDP_CLIENT_FIND_SERVER)
         data = write_presend(data)
-        self.send_packet(addr, data)
+        return self.send_packet(addr, data, new_connection=new_connection)
 
-    def send_PACKET_UDP_MASTER_RESPONSE_LIST(self, addr, slt, servers):
+    def send_PACKET_UDP_MASTER_RESPONSE_LIST(self, addr, slt, servers, new_connection=False):
         data = write_init(PacketUDPType.PACKET_UDP_MASTER_RESPONSE_LIST)
         data = write_uint8(data, slt.value + 1)
         data = write_uint16(data, len(servers))
@@ -35,4 +35,4 @@ class OpenTTDProtocolSend:
                 data = write_uint8(data, packed[i])
             data = write_uint16(data, server["port"])
         data = write_presend(data)
-        self.send_packet(addr, data)
+        return self.send_packet(addr, data, new_connection=new_connection)

--- a/requirements.base
+++ b/requirements.base
@@ -1,4 +1,5 @@
 aiohttp
 click
 sentry-sdk
+pproxy
 PynamoDB

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ docutils==0.15.2
 idna==2.10
 jmespath==0.10.0
 multidict==4.7.6
+pproxy==2.3.5
 pynamodb==4.3.3
 python-dateutil==2.8.1
 sentry-sdk==0.17.3


### PR DESCRIPTION
In the way we currently deploy this in production, it runs on
AWS ECS which does not support IPv6 for containers. As we query
game servers from the container, a new outgoing connection has
to be created which supports both IPv4 and IPv6. By using a SOCKS
proxy deployed within the AWS VPC, we can now query game servers
from within the container without AWS ECS supporting IPv6.

Of course as soon as AWS supports IPv6 for AWS ECS this can be
dropped.