### PR TITLE
Fix: don't log every time a server is not responding

### DIFF
--- a/master_server/application/master_server_query.py
+++ b/master_server/application/master_server_query.py
@@ -47,8 +47,6 @@ class Common:
 
             retry_left -= 1
 
-        log.info("No response from %s:%d after %d attempts", ip, port, retry)
-
         # Forget about this query, as we consider it failed
         ms_key = (ip, port)
         del self._ms_mapping[ms_key]


### PR DESCRIPTION
This happens often enough in production that it blurs the logs
from what is really going wrong. It turns out a lot of people
have their advertisement on, but they never really advertise.
This is most likely due to their firewall not allowing all
required traffic for a gameserver to be advertised.