### PR TITLE
Add: ability to blacklist certain servernames and blacklist "elitegameservers.net"

### DIFF
--- a/master_server/application/master_server.py
+++ b/master_server/application/master_server.py
@@ -28,6 +28,7 @@ TIME_BETWEEN_STALE_CHECK = 60 * 5
 # This to counter server-owners who use our server-listing as advertisement
 # platform. Yes. This was really happening.
 BLACKLISTED_SERVER_NAMES = [
+    "elitegameservers.net",
 ]
 
 


### PR DESCRIPTION
I make this commit with a heavy heart. I rather had that this was completely unneeded, and that people would play fair. Sadly, we are forced to react to a company that insist on using our service to advertise their own. This is, in any ethical sense, not okay.

---

First commit:
```
This is sadly enough needed to combat server-owners that are
using our server-listing as advertisement platform. Although
companies are absolutely free to rent out servers to play OpenTTD,
it is not okay to use our server-listing to advertise.
```

Second commit:
```
They not only have a ton of fake servers (which are NOT intended
to really play on) online, they also add a client to the server
to get them higher on the server-list.
This kind of behaviour is disruptive for our service, and many
players have complained about this behaviour over the last
few days.
Before this week they were running an old version and had no
clients online. Although still not really the intention of our
service, it was not hindering users a lot.
With their new Modus Operandi, their way of using our service
as advertisement platform became a lot more disruptive.

We regret that this action is needed, but we also see no
other way. Using services you don't pay for to advertise
your own service is of poor taste.
```