### PR TITLE
Fix: pproxy changed their API without telling anyone

### DIFF
--- a/master_server/openttd/udp.py
+++ b/master_server/openttd/udp.py
@@ -98,7 +98,7 @@ class OpenTTDProtocolUDP(asyncio.DatagramProtocol, OpenTTDProtocolReceive, OpenT
     def send_packet(self, socket_addr, data, new_connection=False):
         if self.socks_proxy and new_connection:
             # Modify the packet to have a SOCKS header with relay information.
-            data = self._socks_conn.prepare_udp_connection(socket_addr[0], socket_addr[1], data)
+            data = self._socks_conn.udp_prepare_connection(socket_addr[0], socket_addr[1], data)
 
             response = asyncio.Future()
             protocol = SocksProtocol(data, response.set_result)


### PR DESCRIPTION
This library doesn't have a changelog, and clearly it saw a need
to change the API without letting anyone know.

Change upstream happened here:
https://github.com/qwj/python-proxy/commit/cb2669b0e97bf2b1469771858f8a831c6d9b8de7#diff-982910a7706c3ae15c6861fc73095d442f355bb2d154166a7da609c865a9d220L323

Mostly, notice how much it sucks to use commit messages like this? For anyone complaining that we ask people to use real commit messages .. this is why :D