### PR TITLE
Feature: redis support as database backend

### DIFF
--- a/master_server/__main__.py
+++ b/master_server/__main__.py
@@ -6,6 +6,7 @@ from openttd_helpers.logging_helper import click_logging
 from openttd_helpers.sentry_helper import click_sentry
 
 from .database.dynamodb import click_database_dynamodb
+from .database.redis import click_database_redis
 from .openttd.udp import click_proxy_protocol
 
 log = logging.getLogger(__name__)
@@ -27,11 +28,12 @@ log = logging.getLogger(__name__)
 )
 @click.option(
     "--db",
-    type=click.Choice(["dynamodb"], case_sensitive=False),
+    type=click.Choice(["dynamodb", "redis"], case_sensitive=False),
     required=True,
     callback=click_helper.import_module("master_server.database", "Database"),
 )
 @click_database_dynamodb
+@click_database_redis
 @click_proxy_protocol
 def main(bind, msu_port, web_port, app, db):
     database = db()

--- a/master_server/application/web_api.py
+++ b/master_server/application/web_api.py
@@ -40,7 +40,7 @@ async def healthz_handler(request):
 async def server_list(request):
     if request.app.server_list_cache is None or time.time() > request.app.server_list_cache["expire"]:
         request.app.server_list_cache = {
-            "servers": request.app.database.get_server_list_for_web(),
+            "servers": await request.app.database.get_server_list_for_web(),
             "expire": time.time() + TIME_SERVER_LIST_CACHE,
         }
 
@@ -57,7 +57,7 @@ async def server_entry(request):
         or time.time() > request.app.server_entry_cache[server_id]["expire"]
     ):
         request.app.server_entry_cache[server_id] = {
-            "server": request.app.database.get_server_info_for_web(server_id),
+            "server": await request.app.database.get_server_info_for_web(server_id),
             "expire": time.time() + TIME_SERVER_ENTRY_CACHE,
         }
 

--- a/master_server/database/dynamodb.py
+++ b/master_server/database/dynamodb.py
@@ -112,18 +112,18 @@ class Database(DatabaseInterface):
             if not model.exists():
                 model.create_table(wait=True)
 
-    def check_session_key_token(self, session_key, token):
+    async def check_session_key_token(self, session_key, token):
         try:
             server = Server.get(session_key)
         except Server.DoesNotExist:
             return False
         return server.token == token
 
-    def store_session_key_token(self, session_key, token):
+    async def store_session_key_token(self, session_key, token):
         server = Server(session_key, token=token, ttl=timedelta(seconds=TTL))
         server.save()
 
-    def server_online(self, session_key, server_ip, server_port, info):
+    async def server_online(self, session_key, server_ip, server_port, info):
         server_id = _get_server_id(server_ip, server_port)
         self._update_ip_port(server_id, session_key)
 
@@ -164,7 +164,7 @@ class Database(DatabaseInterface):
 
         return True
 
-    def server_offline(self, server_ip, server_port):
+    async def server_offline(self, server_ip, server_port):
         server_id = _get_server_id(server_ip, server_port)
 
         # Lookup the session-key based on the ip/port.
@@ -189,7 +189,7 @@ class Database(DatabaseInterface):
             ]
         )
 
-    def get_server_list_for_client(self, ipv6_list):
+    async def get_server_list_for_client(self, ipv6_list):
         server_list = []
 
         for ip_port in IpPort.online_view.query(True):
@@ -205,7 +205,7 @@ class Database(DatabaseInterface):
 
         return server_list
 
-    def get_server_info_for_web(self, server_id):
+    async def get_server_info_for_web(self, server_id):
         try:
             ip_port = IpPort.get(server_id)
         except IpPort.DoesNotExist:
@@ -218,7 +218,7 @@ class Database(DatabaseInterface):
 
         return _convert_server_to_dict(server)
 
-    def get_server_list_for_web(self):
+    async def get_server_list_for_web(self):
         return [_convert_server_to_dict(server) for server in Server.online_view.query(True)]
 
     def check_stale_servers(self):

--- a/master_server/database/redis.py
+++ b/master_server/database/redis.py
@@ -1,0 +1,162 @@
+import aioredis
+import click
+import hashlib
+import ipaddress
+import json
+import logging
+
+from openttd_helpers import click_helper
+
+from .interface import DatabaseInterface
+
+log = logging.getLogger(__name__)
+
+_redis_url = None
+
+# Servers should announce every 15 minutes, so if we haven't seen a server
+# after 20 minutes, we can assume it is no longer running.
+TTL = 60 * 20
+
+
+def md5sum(value):
+    return hashlib.md5(value.encode()).digest().hex()
+
+
+def _get_server_id(server_ip, server_port):
+    if isinstance(server_ip, ipaddress.IPv6Address):
+        return md5sum(f"[{server_ip}]:{server_port}")
+    else:
+        return md5sum(f"{server_ip}:{server_port}")
+
+
+class Database(DatabaseInterface):
+    def __init__(self):
+        self._redis = aioredis.from_url(_redis_url, decode_responses=True)
+
+    async def check_session_key_token(self, session_key, token):
+        ms_token = await self._redis.get(f"ms-session-key:{session_key}")
+        if ms_token is None:
+            return False
+
+        if ms_token != str(token):
+            return False
+
+        await self._redis.expire(f"ms-session-key:{session_key}", TTL)
+        return True
+
+    async def store_session_key_token(self, session_key, token):
+        await self._redis.set(f"ms-session-key:{session_key}", token, ex=TTL)
+
+    async def server_online(self, session_key, server_ip, server_port, info):
+        # Don't accept servers with empty revision or name.
+        if info["openttd_version"] == "" or info["name"] == "":
+            return False
+
+        # server_offline() doesn't get the session_key, so we need a reverse lookup.
+        await self._redis.set(f"ms-session-id:{server_ip}:{server_port}", session_key, ex=TTL)
+
+        info["game_type"] = 1  # Public
+
+        # Update the information of this server.
+        info_str = json.dumps(info)
+        await self._redis.set(f"gc-server:{session_key}", info_str, ex=TTL)
+        await self._redis.xadd("gc-stream", {"gc-id": -1, "update": session_key, "info": info_str}, approximate=1000)
+
+        # Track this IP based on the session_key.
+        if isinstance(server_ip, ipaddress.IPv6Address):
+            type = "ipv6"
+        else:
+            type = "ipv4"
+        server_str = json.dumps({"ip": str(server_ip), "port": server_port})
+        if await self._redis.set(f"gc-direct-{type}:{session_key}", server_str, ex=TTL) > 0:
+            await self._redis.xadd(
+                "gc-stream", {"gc-id": -1, f"new-direct-{type}": session_key, "server": server_str}, approximate=1000
+            )
+
+        return True
+
+    async def server_offline(self, server_ip, server_port):
+        # Find the session-key of this ip:port combination.
+        session_key = await self._redis.get(f"ms-session-id:{server_ip}:{server_port}")
+        if session_key is None:
+            return
+        await self._redis.delete(f"ms-session-id:{server_ip}:{server_port}")
+
+        await self._redis.delete(f"gc-direct-ipv4:{session_key}")
+        await self._redis.delete(f"gc-direct-ipv6:{session_key}")
+
+        # Delete this server.
+        if await self._redis.delete(f"gc-server:{session_key}") > 0:
+            await self._redis.xadd("gc-stream", {"gc-id": -1, "delete": session_key}, approximate=1000)
+
+    async def get_server_list_for_client(self, ipv6_list):
+        if ipv6_list:
+            type = "ipv6"
+            ipcls = ipaddress.IPv6Address
+        else:
+            type = "ipv4"
+            ipcls = ipaddress.IPv4Address
+
+        server_list = []
+        direct_ips = await self._redis.keys(f"gc-direct-{type}:*")
+        for direct_ip_key in direct_ips:
+            direct_ip_str = await self._redis.get(direct_ip_key)
+            direct_ip = json.loads(direct_ip_str)
+            direct_ip["ip"] = ipcls(direct_ip["ip"])
+            server_list.append(direct_ip)
+
+        return server_list
+
+    async def get_server_info_for_web(self, server_id):
+        info_str = await self._redis.get(f"gc-server:{server_id}")
+        entry = {
+            "info": json.loads(info_str),
+            "online": True,
+        }
+
+        direct_ipv4_str = await self._redis.get(f"gc-direct-ipv4:{server_id}")
+        if direct_ipv4_str:
+            direct_ipv4 = json.loads(direct_ipv4_str)
+            entry["ipv4"] = {
+                "ip": direct_ipv4["ip"],
+                "port": direct_ipv4["port"],
+                "server_id": _get_server_id(direct_ipv4["ip"], direct_ipv4["port"]),
+            }
+
+        direct_ipv6_str = await self._redis.get(f"gc-direct-ipv6:{server_id}")
+        if direct_ipv6_str:
+            direct_ipv6 = json.loads(direct_ipv6_str)
+            entry["ipv6"] = {
+                "ip": direct_ipv6["ip"],
+                "port": direct_ipv6["port"],
+                "server_id": direct_ipv6(direct_ipv4["ip"], direct_ipv6["port"]),
+            }
+
+        return entry
+
+    async def get_server_list_for_web(self):
+        server_list = []
+
+        servers = await self._redis.keys("gc-server:*")
+        for server_key in servers:
+            _, _, server_id = server_key.partition(":")
+            entry = self.get_server_info_for_web(server_id)
+            server_list.append(entry)
+
+        return server_list
+
+    def check_stale_servers(self):
+        # Redis takes care of this for us.
+        pass
+
+
+@click_helper.extend
+@click.option(
+    "--redis-url",
+    help="URL of the redis server.",
+    default="redis://localhost",
+)
+def click_database_redis(redis_url):
+    global _redis_url
+
+    _redis_url = redis_url

--- a/requirements.base
+++ b/requirements.base
@@ -1,4 +1,5 @@
 aiohttp
+aioredis
 click
 sentry-sdk
 openttd-helpers

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiohttp==3.7.4.post0
+aioredis==2.0.0a1
 async-timeout==3.0.1
 attrs==21.2.0
 botocore==1.20.103
@@ -6,6 +7,7 @@ certifi==2021.5.30
 chardet==4.0.0
 click==8.0.1
 docutils==0.17.1
+hiredis==2.0.0
 idna==3.2
 jmespath==0.10.0
 multidict==5.1.0


### PR DESCRIPTION
This allows the Master Server to talk to redis, as a replacement for dynamoDB.

The code has some changes to sync it up with the Game Coordinator, so what they store in redis can be understood by both. This is why some keys are `gc-server` etc.

With this, and https://github.com/OpenTTD/game-coordinator/pull/5 , the Master Server and Game Coordinator now see each others servers. This means that for a 1.11.2 clients a 1.12 server is listed (but you cannot query information from it). And for a 1.12 client you can see a 1.11.2 server (you see al information, but cannot join it because of the version mismatch).