### PR TITLE
Change: rename fields in the API to more match what it does

### DIFF
--- a/master_server/application/master_server.py
+++ b/master_server/application/master_server.py
@@ -198,7 +198,7 @@ class Application(Common):
         # it invisible for the server it is not listed.
         # And yes, this was sadly enough needed, as some server-owners decided
         # to use our server-listing as advertisement platform.
-        server_name = info["server_name"].lower()
+        server_name = info["name"].lower()
         for blacklisted_server_name in BLACKLISTED_SERVER_NAMES:
             if blacklisted_server_name in server_name:
                 break

--- a/master_server/database/dynamodb.py
+++ b/master_server/database/dynamodb.py
@@ -61,13 +61,13 @@ def _convert_server_to_dict(server):
         }
 
     for name, _ in getmembers(InfoMap, lambda o: isinstance(o, Attribute)):
-        if name == "grfs":
-            entry["info"]["grfs"] = [
+        if name == "newgrfs":
+            entry["info"]["newgrfs"] = [
                 {
-                    "grfid": grf["grfid"],
-                    "md5sum": grf["md5sum"].hex(),
+                    "grfid": newgrf["grfid"],
+                    "md5sum": newgrf["md5sum"].hex(),
                 }
-                for grf in getattr(server.info, name)
+                for newgrf in getattr(server.info, name)
             ]
         else:
             entry["info"][name] = getattr(server.info, name)
@@ -133,7 +133,7 @@ class Database(DatabaseInterface):
             return False
 
         # Don't accept servers with empty revision or name.
-        if info["server_revision"] == "" or info["server_name"] == "":
+        if info["openttd_version"] == "" or info["name"] == "":
             return False
 
         # Update the server information.

--- a/master_server/database/dynamodb_models.py
+++ b/master_server/database/dynamodb_models.py
@@ -35,25 +35,22 @@ class GrfMap(MapAttribute):
 
 
 class InfoMap(MapAttribute):
-    num_grfs = NumberAttribute()
-    grfs = ListAttribute(of=GrfMap)
+    newgrfs = ListAttribute(of=GrfMap)
     game_date = NumberAttribute()
     start_date = NumberAttribute()
     companies_max = NumberAttribute()
     companies_on = NumberAttribute()
     spectators_max = NumberAttribute()
-    server_name = UnicodeAttribute()
-    server_revision = UnicodeAttribute()
-    server_lang = NumberAttribute()
+    name = UnicodeAttribute()
+    openttd_version = UnicodeAttribute()
     use_password = NumberAttribute()
     clients_max = NumberAttribute()
     clients_on = NumberAttribute()
     spectators_on = NumberAttribute()
-    map_name = UnicodeAttribute(null=True)
     map_width = NumberAttribute()
     map_height = NumberAttribute()
-    map_set = NumberAttribute()
-    dedicated = NumberAttribute()
+    map_type = NumberAttribute()
+    is_dedicated = NumberAttribute()
 
     def __repr__(self):
         return str(vars(self))

--- a/master_server/openttd/receive.py
+++ b/master_server/openttd/receive.py
@@ -104,37 +104,34 @@ class OpenTTDProtocolReceive:
         payload = {
             name: None
             for name in [
-                "num_grfs",
-                "grfs",
+                "newgrfs",
                 "game_date",
                 "start_date",
                 "companies_max",
                 "companies_on",
                 "spectators_max",
-                "server_name",
-                "server_revision",
-                "server_lang",
+                "name",
+                "openttd_version",
                 "use_password",
                 "clients_max",
                 "clients_on",
                 "spectators_on",
-                "map_name",
                 "map_width",
                 "map_height",
-                "map_set",
-                "dedicated",
+                "map_type",
+                "is_dedicated",
             ]
         }
 
         game_info_version, data = read_uint8(data)
 
         if game_info_version >= 4:
-            payload["num_grfs"], data = read_uint8(data)
-            payload["grfs"] = []
-            for _ in range(payload["num_grfs"]):
+            newgrf_count, data = read_uint8(data)
+            payload["newgrfs"] = []
+            for _ in range(newgrf_count):
                 grfid, data = read_uint32(data)
                 md5sum, data = read_bytes(data, 16)
-                payload["grfs"].append({"grfid": grfid, "md5sum": md5sum})
+                payload["newgrfs"].append({"grfid": grfid, "md5sum": md5sum})
 
         if game_info_version >= 3:
             payload["game_date"], data = read_uint32(data)
@@ -146,9 +143,9 @@ class OpenTTDProtocolReceive:
             payload["spectators_max"], data = read_uint8(data)
 
         if game_info_version >= 1:
-            payload["server_name"], data = read_string(data)
-            payload["server_revision"], data = read_string(data)
-            payload["server_lang"], data = read_uint8(data)
+            payload["name"], data = read_string(data)
+            payload["openttd_version"], data = read_string(data)
+            _, data = read_uint8(data)  # Unused, used to be server-lang
             payload["use_password"], data = read_uint8(data)
             payload["clients_max"], data = read_uint8(data)
             payload["clients_on"], data = read_uint8(data)
@@ -158,11 +155,11 @@ class OpenTTDProtocolReceive:
                 payload["game_date"] += DAYS_TILL_ORIGINAL_BASE_YEAR
                 payload["start_date"], data = read_uint16(data)
                 payload["start_date"] += DAYS_TILL_ORIGINAL_BASE_YEAR
-            payload["map_name"], data = read_string(data)
+            _, data = read_string(data)  # Unused, used to be map-name
             payload["map_width"], data = read_uint16(data)
             payload["map_height"], data = read_uint16(data)
-            payload["map_set"], data = read_uint8(data)
-            payload["dedicated"], data = read_uint8(data)
+            payload["map_type"], data = read_uint8(data)
+            payload["is_dedicated"], data = read_uint8(data)
 
         if len(data) != 0:
             raise PacketInvalidData("more bytes than expected")


### PR DESCRIPTION
A while ago we renamed a bunch of variables in the OpenTTD client,
as this old list of names wasn't always that obvious. Now we apply
the same change to the API too.

This is also needed to make sure the master-server is talking
the same language as the new upcoming game-coordinator.

This is what is changing:

`server_name` -> `name` (we already know it is a server ..)
`server_revision` -> `openttd_version`
`map_set` -> `map_type`
`grfs` -> `newgrfs`
`dedicated` -> `is_dedicated`
`language` -> removed (was always ALL for 1.11)
`map_name` -> removed (was always "" for 1.11)
`num_grfs` -> removed (just count the entries in `newgrfs`, no need to tell you twice)

I did ponder about adding an API versioning, and clue the old fields back in .. but I realised that https://github.com/OpenTTD/master-server-web is most likely the only consumer of the API, so it felt like a lot of effort for zero gain.