### PR TITLE
Fix: move "server_id" key in API to server-level

### DIFF
--- a/master_server/database/dynamodb.py
+++ b/master_server/database/dynamodb.py
@@ -42,23 +42,23 @@ def _get_server_id(server_ip, server_port):
 def _convert_server_to_dict(server):
     entry = {
         "info": {},
-        "time_first_seen": server.time_first_seen,
-        "time_last_seen": server.time_last_seen,
-        "online": server.online,
     }
 
     if server.ipv4:
         entry["ipv4"] = {
             "ip": str(server.ipv4.ip),
             "port": server.ipv4.port,
-            "server_id": _get_server_id(server.ipv4.ip, server.ipv4.port),
         }
+        entry["server_id"] = _get_server_id(server.ipv4.ip, server.ipv4.port)
+
     if server.ipv6:
         entry["ipv6"] = {
             "ip": str(server.ipv6.ip),
             "port": server.ipv6.port,
-            "server_id": _get_server_id(server.ipv6.ip, server.ipv6.port),
         }
+        # Make sure the IPv4 variant always wins.
+        if "server_id" not in entry:
+            entry["server_id"] = _get_server_id(server.ipv6.ip, server.ipv6.port)
 
     for name, _ in getmembers(InfoMap, lambda o: isinstance(o, Attribute)):
         if name == "newgrfs":

--- a/master_server/database/redis.py
+++ b/master_server/database/redis.py
@@ -133,7 +133,7 @@ class Database(DatabaseInterface):
 
         entry = {
             "info": info,
-            "online": True,
+            "server_id": server_id,
         }
 
         direct_ipv4_str = await self._redis.get(f"gc-direct-ipv4:{server_id}")
@@ -142,7 +142,6 @@ class Database(DatabaseInterface):
             entry["ipv4"] = {
                 "ip": direct_ipv4["ip"],
                 "port": direct_ipv4["port"],
-                "server_id": server_id,
             }
 
         direct_ipv6_str = await self._redis.get(f"gc-direct-ipv6:{server_id}")
@@ -151,7 +150,6 @@ class Database(DatabaseInterface):
             entry["ipv6"] = {
                 "ip": direct_ipv6["ip"],
                 "port": direct_ipv6["port"],
-                "server_id": server_id,
             }
 
         return entry


### PR DESCRIPTION
With the recent change to make server_ids independent of IPv4/IPv6,
there is no longer any need to add them twice in the JSON blob.

While at it remove unused fields too.