### PR TITLE
Fix: server-info was missing the new gamescript entries

### DIFF
--- a/master_server/openttd/receive.py
+++ b/master_server/openttd/receive.py
@@ -104,6 +104,8 @@ class OpenTTDProtocolReceive:
         payload = {
             name: None
             for name in [
+                "gamescript_version",
+                "gamescript_name",
                 "newgrfs",
                 "game_date",
                 "start_date",


### PR DESCRIPTION
These can remain empty, but the info-blob should be the same between
game-coordinator and master-server in all cases.