### PR TITLE
Fix: main eventloop is not running while webserver is

### DIFF
--- a/master_server/application/master_server.py
+++ b/master_server/application/master_server.py
@@ -86,7 +86,7 @@ class Application(Common):
         webapp = web.Application()
         webapp.add_routes(routes)
 
-        web.run_app(webapp, host=bind, port=web_port, access_log_class=ErrorOnlyAccessLogger)
+        web.run_app(webapp, host=bind, port=web_port, access_log_class=ErrorOnlyAccessLogger, loop=loop)
 
         log.info("Shutting down master server ...")
 


### PR DESCRIPTION
run_app() runs the webserver till it is done (read: never), but
since the latest aiohttp it does this in its own eventloop. Read:
the main eventloop is not running inside run_app().

Fix this by explicitly telling to use the mainloop instead.